### PR TITLE
Fix/query-shipping-address-for-shared-orgs 

### DIFF
--- a/src/fragments/CoreAccountFragment.ts
+++ b/src/fragments/CoreAccountFragment.ts
@@ -89,6 +89,16 @@ export const CoreAccountFragment = gql`
             ...CoreAddressFragment
           }
         }
+        shipping {
+          primary {
+            id
+            ...CoreAddressFragment
+          }
+          secondary {
+            id
+            ...CoreAddressFragment
+          }
+        }
       }
       administration {
         email


### PR DESCRIPTION
fix: add shipping to shared organisations in CoreAccountFragment