### PR TITLE
Fix/account-order-original-amount 

### DIFF
--- a/src/queries/getAccountOrderQuery.ts
+++ b/src/queries/getAccountOrderQuery.ts
@@ -244,6 +244,7 @@ export const getAccountOrderQuery = gql`
           quantity
           pricing {
             amount
+            original_amount
           }
           delivery {
             method {


### PR DESCRIPTION
fix: fetch original_amount of items for account orders